### PR TITLE
plain text comparison to passwords

### DIFF
--- a/src/main/java/org/dlearn/helsinki/skeleton/security/PasswordEncoderDummy.java
+++ b/src/main/java/org/dlearn/helsinki/skeleton/security/PasswordEncoderDummy.java
@@ -14,10 +14,10 @@ public class PasswordEncoderDummy implements PasswordEncoder {
         return rawPassword.toString();
     }
 
-    // Password always matches
+    // Plain text comparison
     @Override
     public boolean matches(CharSequence rawPassword, String encodedPassword) {
-        return true;
+        return rawPassword.toString().equals(encodedPassword);
     }
 
 }


### PR DESCRIPTION
Login should now check "correct" plaintext passwords